### PR TITLE
vendorField Validation

### DIFF
--- a/src/components/ark-qrcode/ark-qrcode.tsx
+++ b/src/components/ark-qrcode/ark-qrcode.tsx
@@ -33,7 +33,7 @@ export class ArkQRCode {
 
   @Watch('vendorField')
   validateVendorField () {
-    if (typeof this.vendorField == 'string' && decodeURIComponent(this.vendorField) == this.vendorField) throw new Error('vendorField: must be a UTF-8 encoded string');
+    if (typeof this.vendorField !== 'string' && decodeURIComponent(this.vendorField) === this.vendorField) throw new Error('vendorField: must be a UTF-8 encoded string');
     if (decodeURIComponent(this.vendorField).length > 64) throw new Error('vendorField: enter no more than 64 characters');
   }
 

--- a/src/components/ark-qrcode/ark-qrcode.tsx
+++ b/src/components/ark-qrcode/ark-qrcode.tsx
@@ -33,7 +33,7 @@ export class ArkQRCode {
 
   @Watch('vendorField')
   validateVendorField () {
-    if (typeof this.vendorField !== 'string' && decodeURIComponent(this.vendorField) === this.vendorField) throw new Error('vendorField: must be a UTF-8 encoded string');
+    if (typeof this.vendorField !== 'string' || decodeURIComponent(this.vendorField) !== this.vendorField) throw new Error('vendorField: must be a UTF-8 encoded string');
     if (decodeURIComponent(this.vendorField).length > 64) throw new Error('vendorField: enter no more than 64 characters');
   }
 


### PR DESCRIPTION
This was causing me grief, but I think this should be changed.
Now it validates if vendorField and throws an error if: 

 - vendorField is NOT a string
 OR
 - vendorField run through decoded URI function is no longer equal to original string